### PR TITLE
feat: add ability to set product ID when creating a product

### DIFF
--- a/stripe/resource_stripe_product.go
+++ b/stripe/resource_stripe_product.go
@@ -19,6 +19,7 @@ func resourceStripeProduct() *schema.Resource {
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Description: "Unique identifier for the object.",
 			},
 			"name": {
@@ -127,6 +128,9 @@ func resourceStripeProductCreate(ctx context.Context, d *schema.ResourceData, m 
 	c := m.(*client.API)
 	params := &stripe.ProductParams{
 		Name: stripe.String(ExtractString(d, "name")),
+	}
+	if productID, ok := d.GetOk("id"); ok {
+		params.ID = stripe.String(ToString(productID))
 	}
 	if active, set := d.GetOk("active"); set {
 		params.Active = stripe.Bool(ToBool(active))


### PR DESCRIPTION
Adds ability to set the product ID when creating a product. This is an optional parameter that Stripe allows per their docs: https://stripe.com/docs/api/products/create