### PR TITLE
Correctly setting statement_descriptor for stripe product post call

### DIFF
--- a/docs/resources/stripe_product.md
+++ b/docs/resources/stripe_product.md
@@ -40,7 +40,7 @@ Arguments accepted by this resource include:
 * `images` - (Optional) List(String). A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
 * `package_dimensions` - (Optional) Map(Float). The dimensions of this product for shipping purposes. When used these fields are required: `height`,`length`,`width` and `weight`; the precision is 2 decimal places.
 * `shippable` - (Optional) Bool. Whether this product is shipped (i.e., physical goods).
-* `statement_descriptor` - (Optional) String. An arbitrary string to be displayed on your customer’s credit card or bank statement. While most banks display this information consistently, some may display it incorrectly or not at all. This may be up to 22 characters. The statement description may not include `<`,` >`, `\`, `"`, `’` characters, and will appear on your customer’s statement in capital letters. Non-ASCII characters are automatically stripped. It must contain at least one letter.
+* `statement_description` - (Optional) String. An arbitrary string to be displayed on your customer’s credit card or bank statement. While most banks display this information consistently, some may display it incorrectly or not at all. This may be up to 22 characters. The statement description may not include `<`,` >`, `\`, `"`, `’` characters, and will appear on your customer’s statement in capital letters. Non-ASCII characters are automatically stripped. It must contain at least one letter.
 * `unit_label` - (Optional) String. A label that represents units of this product in Stripe and on customers’ receipts and invoices. When set, this will be included in associated invoice line item descriptions.
 * `url` - (Optional) String. A URL of a publicly-accessible webpage for this product.
 * `metadata` - (Optional) Map(String). Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
@@ -56,7 +56,7 @@ Attributes exported by this resource include:
 * `images` - List(String). A list of up to 8 URLs of images for this product.
 * `package_dimensions` - Map(Float). The dimensions of this product for shipping purposes.
 * `shippable` - Bool. Whether this product is shipped (i.e., physical goods).
-* `statement_descriptor` - String. An arbitrary string to be displayed on your customer’s credit card or bank statement.
+* `statement_description` - String. An arbitrary string to be displayed on your customer’s credit card or bank statement.
 * `unit_label` - String. A label that represents units of this product in Stripe and on customers’ receipts and invoices. 
 * `url` - String. A URL of a publicly-accessible webpage for this product.
 * `metadata` - Map(String). Set of key-value pairs that you can attach to an object.

--- a/docs/resources/stripe_product.md
+++ b/docs/resources/stripe_product.md
@@ -40,7 +40,7 @@ Arguments accepted by this resource include:
 * `images` - (Optional) List(String). A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
 * `package_dimensions` - (Optional) Map(Float). The dimensions of this product for shipping purposes. When used these fields are required: `height`,`length`,`width` and `weight`; the precision is 2 decimal places.
 * `shippable` - (Optional) Bool. Whether this product is shipped (i.e., physical goods).
-* `statement_description` - (Optional) String. An arbitrary string to be displayed on your customer’s credit card or bank statement. While most banks display this information consistently, some may display it incorrectly or not at all. This may be up to 22 characters. The statement description may not include `<`,` >`, `\`, `"`, `’` characters, and will appear on your customer’s statement in capital letters. Non-ASCII characters are automatically stripped. It must contain at least one letter.
+* `statement_descriptor` - (Optional) String. An arbitrary string to be displayed on your customer’s credit card or bank statement. While most banks display this information consistently, some may display it incorrectly or not at all. This may be up to 22 characters. The statement description may not include `<`,` >`, `\`, `"`, `’` characters, and will appear on your customer’s statement in capital letters. Non-ASCII characters are automatically stripped. It must contain at least one letter.
 * `unit_label` - (Optional) String. A label that represents units of this product in Stripe and on customers’ receipts and invoices. When set, this will be included in associated invoice line item descriptions.
 * `url` - (Optional) String. A URL of a publicly-accessible webpage for this product.
 * `metadata` - (Optional) Map(String). Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
@@ -56,7 +56,7 @@ Attributes exported by this resource include:
 * `images` - List(String). A list of up to 8 URLs of images for this product.
 * `package_dimensions` - Map(Float). The dimensions of this product for shipping purposes.
 * `shippable` - Bool. Whether this product is shipped (i.e., physical goods).
-* `statement_description` - String. An arbitrary string to be displayed on your customer’s credit card or bank statement.
+* `statement_descriptor` - String. An arbitrary string to be displayed on your customer’s credit card or bank statement.
 * `unit_label` - String. A label that represents units of this product in Stripe and on customers’ receipts and invoices. 
 * `url` - String. A URL of a publicly-accessible webpage for this product.
 * `metadata` - Map(String). Set of key-value pairs that you can attach to an object.

--- a/stripe/resource_stripe_product.go
+++ b/stripe/resource_stripe_product.go
@@ -160,7 +160,7 @@ func resourceStripeProductCreate(ctx context.Context, d *schema.ResourceData, m 
 	if shippable, set := d.GetOk("shippable"); set {
 		params.Shippable = stripe.Bool(ToBool(shippable))
 	}
-	if statementDescriptor, set := d.GetOk("statement_description"); set {
+	if statementDescriptor, set := d.GetOk("statement_descriptor"); set {
 		params.StatementDescriptor = stripe.String(ToString(statementDescriptor))
 	}
 	if unitLabel, set := d.GetOk("unit_label"); set {


### PR DESCRIPTION
The stripe product creation was referencing statement_description which meant that it was never setting the statement_descriptor value in stripe