### PR TITLE
Handle `unit_amount` being returned when `unit_amount_decimal` is set or vice versa

### DIFF
--- a/stripe/resource_stripe_price.go
+++ b/stripe/resource_stripe_price.go
@@ -235,8 +235,17 @@ func resourceStripePriceRead(_ context.Context, d *schema.ResourceData, m interf
 	return CallSet(
 		d.Set("currency", price.Currency),
 		d.Set("product", price.Product.ID),
-		d.Set("unit_amount", price.UnitAmount),
-		d.Set("unit_amount_decimal", price.UnitAmountDecimal),
+		func() error {
+			// We should only every fall into one of these if statements as we have a conflict between them on the schema
+			if d.HasChange("unit_amount") && !d.HasChange("unit_amount_decimal") {
+				d.Set("unit_amount", price.UnitAmount)
+			}
+			if d.HasChange("unit_amount_decimal") && !d.HasChange("unit_amount") {
+				d.Set("unit_amount_decimal", price.UnitAmountDecimal)
+			}
+
+			return nil
+		}(),
 		d.Set("active", price.Active),
 		d.Set("nickname", price.Nickname),
 		func() error {


### PR DESCRIPTION
From my understanding stripe is returning the `unit_amount` and `unit_amount_decimal` back even if we didn't set one of them which meant that our Terraform config was null for one of the variables but the state held the value that was given back form stripe.
As a fix, I'm checking if we have changed the variables in Terraform before running the d.set command on them. Only 1 of them can be set at a time.

Ticket resolves #6 