### PR TITLE
fix: optional amount values for price tiers

### DIFF
--- a/stripe/resource_stripe_price.go
+++ b/stripe/resource_stripe_price.go
@@ -354,13 +354,13 @@ func resourceStripePriceCreate(ctx context.Context, d *schema.ResourceData, m in
 						priceTier.UpTo = stripe.Int64(ToInt64(v))
 					}
 				case k == "flat_amount":
-					priceTier.FlatAmount = stripe.Int64(ToInt64(v))
+					priceTier.FlatAmount = OptionalInt64(v)
 				case k == "flat_amount_decimal":
-					priceTier.FlatAmountDecimal = stripe.Float64(ToFloat64(v))
+					priceTier.FlatAmountDecimal = OptionalFloat64(v)
 				case k == "unit_amount":
-					priceTier.UnitAmount = stripe.Int64(ToInt64(v))
+					priceTier.UnitAmount = OptionalInt64(v)
 				case k == "unit_amount_decimal":
-					priceTier.UnitAmountDecimal = stripe.Float64(ToFloat64(v))
+					priceTier.UnitAmountDecimal = OptionalFloat64(v)
 				}
 			}
 			params.Tiers = append(params.Tiers, priceTier)

--- a/stripe/utils.go
+++ b/stripe/utils.go
@@ -58,6 +58,30 @@ func ToInt64(value interface{}) int64 {
 	}
 }
 
+func OptionalInt64(value interface{}) *int64 {
+	valueInt64 := ToInt64(value)
+	switch valueInt64 {
+	case 0:
+		return nil
+	case -1:
+		return new(int64)
+	default:
+		return &valueInt64
+	}
+}
+
+func OptionalFloat64(value interface{}) *float64 {
+	valueFloat64 := ToFloat64(value)
+	switch valueFloat64 {
+	case 0:
+		return nil
+	case -1:
+		return new(float64)
+	default:
+		return &valueFloat64
+	}
+}
+
 func ExtractFloat64(d *schema.ResourceData, key string) float64 {
 	return ToFloat64(d.Get(key))
 }


### PR DESCRIPTION
The idea of this PR is to extend the concept that is already in place on the project that, if the user indeed wants to send "0", it should be set as "-1" on the `.tf` file. Otherwise, consider "0" as unset.
Not sure if there is a more elegant way to know if the value was set like it is possible for the `ResourceData`. If so, I think that would be a better approach.

This closes #10 