### PR TITLE
Disable portal configurations on removal

### DIFF
--- a/stripe/resource_stripe_portal_configuration.go
+++ b/stripe/resource_stripe_portal_configuration.go
@@ -534,7 +534,17 @@ func resourceStripePortalConfigurationUpdate(ctx context.Context, d *schema.Reso
 }
 
 func resourceStripePortalConfigurationDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Println("[WARN] Stripe doesn't support deletion of customer portals through the API")
+	log.Println("[WARN] Stripe doesn't support deletion of customer portals. Portal will be deactivated but not deleted")
+
+	c := m.(*client.API)
+	params := stripe.BillingPortalConfigurationParams{
+		Active: stripe.Bool(false),
+	}
+
+	if _, err := c.BillingPortalConfigurations.Update(d.Id(), &params); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId("")
 	return nil
 }


### PR DESCRIPTION
Stripe doesn't provide the ability to delete portal configurations.
Previously we would do nothing on removal, we now propose to deactivate
them, similar to the behaviour implemented when removing prices.