### PR TITLE
Get list of products a coupon applies to

### DIFF
--- a/stripe/resource_stripe_coupon.go
+++ b/stripe/resource_stripe_coupon.go
@@ -162,8 +162,10 @@ func resourceStripeCouponCreate(ctx context.Context, d *schema.ResourceData, m i
 
 func resourceStripeCouponRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.API)
+	p := &stripe.CouponParams{}
+	p.AddExpand("applies_to")
 
-	coupon, err := c.Coupons.Get(d.Id(), nil)
+	coupon, err := c.Coupons.Get(d.Id(), p)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
When creating a coupon that applies to a specific product, on each terraform refresh, the planner attempts to re create the coupon because the `applies_to` field is always empty. 

To get the `applies_to` value, we need to specifically request it on the call. https://stripe.com/docs/api/coupons/object#coupon_object-applies_to
One of those Stripe surprises...