### PR TITLE
Fix inconsistency/typo in Customer Portal subscription_cancel

### DIFF
--- a/stripe/resource_stripe_portal_configuration.go
+++ b/stripe/resource_stripe_portal_configuration.go
@@ -469,7 +469,7 @@ func resourceStripePortalConfigurationCreate(ctx context.Context, d *schema.Reso
 						params.Features.SubscriptionCancel = &stripe.BillingPortalConfigurationFeaturesSubscriptionCancelParams{}
 						for k, v := range subsCancelMap {
 							switch k {
-							case "enable":
+							case "enabled":
 								params.Features.SubscriptionCancel.Enabled = stripe.Bool(ToBool(v))
 							case "mode":
 								params.Features.SubscriptionCancel.Mode = NonZeroString(v)
@@ -632,7 +632,7 @@ func resourceStripePortalConfigurationUpdate(ctx context.Context, d *schema.Reso
 						params.Features.SubscriptionCancel = &stripe.BillingPortalConfigurationFeaturesSubscriptionCancelParams{}
 						for k, v := range subsCancelMap {
 							switch k {
-							case "enable":
+							case "enabled":
 								params.Features.SubscriptionCancel.Enabled = stripe.Bool(ToBool(v))
 							case "mode":
 								params.Features.SubscriptionCancel.Mode = NonZeroString(v)


### PR DESCRIPTION
Tiny fix for the switch case reading the Terraform configuration -- it was looking for `enable` over `enabled`.
All the other `features` are using `enabled` as does the Stripe and the plugin documentation.