### PR TITLE
Expand subscription update products on Billing Portal

### DIFF
--- a/stripe/resource_stripe_portal_configuration.go
+++ b/stripe/resource_stripe_portal_configuration.go
@@ -273,8 +273,11 @@ func resourceStripePortalConfigurationRead(_ context.Context, d *schema.Resource
 	var portal *stripe.BillingPortalConfiguration
 	var err error
 
+	params := &stripe.BillingPortalConfigurationParams{}
+	params.AddExpand("features.subscription_update.products")
+
 	err = retryWithBackOff(func() error {
-		portal, err = c.BillingPortalConfigurations.Get(d.Id(), nil)
+		portal, err = c.BillingPortalConfigurations.Get(d.Id(), params)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
On my setup, Terraform plan is always attempting to add products on portal configurations because it has no visibility on what currently exists on the Stripe side.
With this change we now request the existing subscription products so terraform doesn't detect these values as missing on Stripe.