### PR TITLE
UnitAmount fix for PriceCurrencyOptions

### DIFF
--- a/docs/resources/stripe_price.md
+++ b/docs/resources/stripe_price.md
@@ -166,7 +166,7 @@ Arguments accepted by this resource include:
   Specifies whether the price is considered inclusive of taxes or exclusive of taxes. 
   One of `inclusive`, `exclusive`, or `unspecified`. 
   Once specified as either inclusive or exclusive, it cannot be changed.
-* `unit_amount` - (Optional) Int. A positive integer in cents (or 0 for a free price) representing how much to charge.
+* `unit_amount` - (Optional) Int. A positive integer in cents (or -1 for a free price) representing how much to charge.
 * `unit_amount_decimal` - (Optional) Float. Same as unit_amount, but accepts a decimal value in cents with at most 12
   decimal places. Only one of unit_amount and unit_amount_decimal can be set.
 * `custom_unit_amount` - (Optional) List(Resource). When set, 

--- a/stripe/resource_stripe_price.go
+++ b/stripe/resource_stripe_price.go
@@ -195,7 +195,7 @@ func resourceStripePrice() *schema.Resource {
 						"unit_amount": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Description: "A positive integer in cents (or 0 for a free price) representing how much to charge.",
+							Description: "A positive integer in cents (or -1 for a free price) representing how much to charge.",
 						},
 						"unit_amount_decimal": {
 							Type:     schema.TypeFloat,
@@ -490,12 +490,7 @@ func resourceStripePriceCreate(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	if unitAmount, set := d.GetOk("unit_amount"); set {
-		amount := ToInt64(unitAmount)
-		// amount is -1 when free price is required
-		if amount < 0 {
-			amount = 0
-		}
-		params.UnitAmount = stripe.Int64(amount)
+		params.UnitAmount = NonZeroInt64(unitAmount)
 	}
 	if unitAmountDecimal, set := d.GetOk("unit_amount_decimal"); set {
 		params.UnitAmountDecimal = stripe.Float64(ToFloat64(unitAmountDecimal))

--- a/stripe/utils.go
+++ b/stripe/utils.go
@@ -66,6 +66,12 @@ func NonZeroInt64(value interface{}) *int64 {
 	if valueInt64 == 0 {
 		return nil
 	}
+
+	// amount is -1 for free price
+	if valueInt64 < 0 {
+		valueInt64 = 0
+	}
+
 	return &valueInt64
 }
 
@@ -73,6 +79,11 @@ func NonZeroFloat64(value interface{}) *float64 {
 	valueFloat64 := ToFloat64(value)
 	if valueFloat64 == 0 {
 		return nil
+	}
+
+	// amount is -1 for free price
+	if valueFloat64 < 0 {
+		valueFloat64 = 0
 	}
 
 	return &valueFloat64


### PR DESCRIPTION
Fix `unit_amount` bug for PriceCurrencyOptions

The expected behavior for all `unit_amount` arguments from the `currency_options` block is to behave similarly to the price `unit_amount` argument.

Right now, `-1 values` (representing the free price) are being sent to Stripe as negative resulting in a validation error while the `0 value` is being dropped by the provider in the `NonZeroInt64` function.