### PR TITLE
Make `api_key` optional in the provider

### DIFF
--- a/stripe/provider.go
+++ b/stripe/provider.go
@@ -14,7 +14,7 @@ func Provider() *schema.Provider {
 			"api_key": {
 				Type:        schema.TypeString,
 				Description: "The Stripe secret API key",
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("STRIPE_API_KEY", nil),
 			},


### PR DESCRIPTION
Making `api_key` optional also removes the type error when using this module in cdktf where TS thinks this is required.


![image](https://github.com/user-attachments/assets/ffa1b84f-1f08-4f5d-8cc2-7a88e0847e42)
