### PR TITLE
Issue 95: portal removal is not supported

### DIFF
--- a/stripe/resource_stripe_file.go
+++ b/stripe/resource_stripe_file.go
@@ -261,7 +261,7 @@ func resourceStripeFileCreate(ctx context.Context, d *schema.ResourceData, m int
 }
 
 func resourceStripeFileDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	log.Println("[WARN] Stripe SDK doesn't support File deletion through API!")
+	log.Println("[WARN] Stripe API doesn't support deletion of file")
 	d.SetId("")
 	return nil
 }

--- a/stripe/resource_stripe_meter.go
+++ b/stripe/resource_stripe_meter.go
@@ -289,21 +289,8 @@ func resourceStripeMeterUpdate(ctx context.Context, d *schema.ResourceData, m in
 	return resourceStripeMeterRead(ctx, d, m)
 }
 
-func resourceStripeMeterDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*client.API)
-	var err error
-
-	params := stripe.BillingMeterDeactivateParams{}
-
-	log.Println("[WARN] Stripe doesn't support deletion of billing meters. Billing meter will be deactivated but not deleted")
-	err = retryWithBackOff(func() error {
-		_, err = c.BillingMeters.Deactivate(d.Id(), &params)
-		return err
-	})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
+func resourceStripeMeterDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	log.Println("[WARN] Stripe API doesn't support deletion of billing meters")
 	d.SetId("")
 	return nil
 }

--- a/stripe/resource_stripe_portal_configuration.go
+++ b/stripe/resource_stripe_portal_configuration.go
@@ -685,23 +685,7 @@ func resourceStripePortalConfigurationUpdate(ctx context.Context, d *schema.Reso
 }
 
 func resourceStripePortalConfigurationDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Println("[WARN] Stripe doesn't support deletion of customer portals. Portal will be deactivated but not deleted")
-
-	c := m.(*client.API)
-	var err error
-
-	params := stripe.BillingPortalConfigurationParams{
-		Active: stripe.Bool(false),
-	}
-
-	err = retryWithBackOff(func() error {
-		_, err = c.BillingPortalConfigurations.Update(d.Id(), &params)
-		return err
-	})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
+	log.Println("[WARN] Stripe API doesn't support deletion of customer portals.")
 	d.SetId("")
 	return nil
 }

--- a/stripe/resource_stripe_promotion_code.go
+++ b/stripe/resource_stripe_promotion_code.go
@@ -266,7 +266,7 @@ func resourceStripePromotionCodeUpdate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceStripePromotionCodeDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	log.Println("[WARN] Stripe SDK doesn't support Promotion Code deletion through API!")
+	log.Println("[WARN] Stripe API doesn't support deletion of promotion code")
 	d.SetId("")
 	return nil
 }

--- a/stripe/resource_stripe_tax_rate.go
+++ b/stripe/resource_stripe_tax_rate.go
@@ -241,7 +241,7 @@ func resourceStripeTaxRateUpdate(ctx context.Context, d *schema.ResourceData, m 
 }
 
 func resourceStripeTaxRateDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	log.Println("[WARN] Stripe SDK doesn't support Tax Rate deletion through API!")
+	log.Println("[WARN] Stripe API doesn't support deletion of tax rate")
 	d.SetId("")
 	return nil
 }


### PR DESCRIPTION
* Customer Portal removal isn't supported through API
* Previously the portal was disabled at the removal step
* When API doesn't support removal don't perform any other actions like set active/disable field. Removal from Terraform state is the only action that happens and user is notified in logs.
* Logic and Log message have been united across resources.